### PR TITLE
Use home_url instead of site_url

### DIFF
--- a/assets/inc/iss-ajax.php
+++ b/assets/inc/iss-ajax.php
@@ -199,7 +199,7 @@ function iss_suggest() {
 			if ( isset( $more ) ) {
 				$results[] = array(
 					'title' => __( 'View all results', 'wpiss' ),
-					'permalink' => add_query_arg( array( 's' => $s ), site_url() ),
+					'permalink' => add_query_arg( array( 's' => $s ), home_url() ),
 					'count'	=> $count,
 					'type' => 'more'
 				);


### PR DESCRIPTION
Fixes broken 'View all results' link if Wordpress installation directory is different
